### PR TITLE
HCP Migration of Workspaces in vjshar/tf-migration repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# These lines were added by the tf-migrate CLI tool
+_hcp-migrate-configs/
+_hcp-migrate-configs-*/
+!_hcp-migrate-configs*/terraform.tfstate
+.terraform.lock.*

--- a/_hcp-migrate-configs/terraform.tfstate
+++ b/_hcp-migrate-configs/terraform.tfstate
@@ -1,0 +1,636 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.6",
+  "serial": 20,
+  "lineage": "d4407262-3cf2-c3fa-3264-e7e9b4af44c9",
+  "outputs": {
+    "count_dir_skipped": {
+      "value": 1,
+      "type": "number"
+    },
+    "list_of_new_project_ids": {
+      "value": [
+        "prj-uFFT3y54wenktA6C",
+        "prj-DjQAdvNV2KzJbH1F"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    },
+    "list_of_new_project_names": {
+      "value": [
+        "example_compute",
+        "example_storage"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "tfe_project",
+      "name": "list_of_new_projects",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "example_compute",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: vjshar/tf-migration",
+            "id": "prj-uFFT3y54wenktA6C",
+            "name": "example_compute",
+            "organization": "TFC-Dev-Env"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "example_storage",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: vjshar/tf-migration",
+            "id": "prj-DjQAdvNV2KzJbH1F",
+            "name": "example_storage",
+            "organization": "TFC-Dev-Env"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: vjshar/tf-migration",
+            "id": "prj-uFFT3y54wenktA6C",
+            "name": "example_compute",
+            "organization": "TFC-Dev-Env",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfe_variable",
+      "name": "variables",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "example_compute_default.string_count",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Number of strings to create",
+            "hcl": false,
+            "id": "var-zn31M33S7v2x1T9x",
+            "key": "string_count",
+            "readable_value": "3",
+            "sensitive": false,
+            "value": "3",
+            "variable_set_id": null,
+            "workspace_id": "ws-21r3t1Yq59D4bdvi"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "example_compute_default.string_length",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Length of each string",
+            "hcl": false,
+            "id": "var-kG1i9EKgMyvQ3nqV",
+            "key": "string_length",
+            "readable_value": "32",
+            "sensitive": false,
+            "value": "32",
+            "variable_set_id": null,
+            "workspace_id": "ws-21r3t1Yq59D4bdvi"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "example_compute_testing.string_count",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Number of strings to create",
+            "hcl": false,
+            "id": "var-A8a9dTd7MgPQ9qzd",
+            "key": "string_count",
+            "readable_value": "3",
+            "sensitive": false,
+            "value": "3",
+            "variable_set_id": null,
+            "workspace_id": "ws-7WBu9JjqChvPcTsh"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "example_compute_testing.string_length",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Length of each string",
+            "hcl": false,
+            "id": "var-6xCXTnox2NzQJbMP",
+            "key": "string_length",
+            "readable_value": "32",
+            "sensitive": false,
+            "value": "32",
+            "variable_set_id": null,
+            "workspace_id": "ws-7WBu9JjqChvPcTsh"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_default",
+            "id": "ws-21r3t1Yq59D4bdvi",
+            "ignore_additional_tag_names": null,
+            "name": "example_compute_default",
+            "operations": true,
+            "organization": "TFC-Dev-Env",
+            "project_id": "prj-uFFT3y54wenktA6C",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_compute"
+            ],
+            "terraform_version": "1.9.6",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_testing",
+            "id": "ws-7WBu9JjqChvPcTsh",
+            "ignore_additional_tag_names": null,
+            "name": "example_compute_testing",
+            "operations": true,
+            "organization": "TFC-Dev-Env",
+            "project_id": "prj-uFFT3y54wenktA6C",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_compute"
+            ],
+            "terraform_version": "1.9.6",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/compute",
+            "local_workspace": "default",
+            "org": "TFC-Dev-Env",
+            "tfc_workspace": "example_compute_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "testing",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/compute",
+            "local_workspace": "testing",
+            "org": "TFC-Dev-Env",
+            "tfc_workspace": "example_compute_testing"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/compute",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/compute\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "main.tf",
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/compute",
+            "org": "TFC-Dev-Env",
+            "project": "example_compute",
+            "tags": [
+              "example_compute"
+            ],
+            "workspace_map": {
+              "default": "example_compute_default",
+              "testing": "example_compute_testing"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: vjshar/tf-migration",
+            "id": "prj-DjQAdvNV2KzJbH1F",
+            "name": "example_storage",
+            "organization": "TFC-Dev-Env",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfe_variable",
+      "name": "variables",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "example_storage_default.string_count",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Number of strings to create",
+            "hcl": false,
+            "id": "var-eSRoPVjiw4eRMmdy",
+            "key": "string_count",
+            "readable_value": "3",
+            "sensitive": false,
+            "value": "3",
+            "variable_set_id": null,
+            "workspace_id": "ws-MWZv4cKYHHKjs9pk"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        },
+        {
+          "index_key": "example_storage_default.string_length",
+          "schema_version": 1,
+          "attributes": {
+            "category": "terraform",
+            "description": "Length of each string",
+            "hcl": false,
+            "id": "var-PSb1dfBS6RUYpoxG",
+            "key": "string_length",
+            "readable_value": "32",
+            "sensitive": false,
+            "value": "32",
+            "variable_set_id": null,
+            "workspace_id": "ws-MWZv4cKYHHKjs9pk"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "value"
+              }
+            ]
+          ],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_storage_default",
+            "id": "ws-MWZv4cKYHHKjs9pk",
+            "ignore_additional_tag_names": null,
+            "name": "example_storage_default",
+            "operations": true,
+            "organization": "TFC-Dev-Env",
+            "project_id": "prj-DjQAdvNV2KzJbH1F",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "Tf-Migrate",
+            "source_url": "https://github.com/hashicorp/tf-migrate",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "example_storage"
+            ],
+            "terraform_version": "1.9.6",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/storage",
+            "local_workspace": "default",
+            "org": "TFC-Dev-Env",
+            "tfc_workspace": "example_storage_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/storage",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"example/storage\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "main.tf",
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/storage",
+            "org": "TFC-Dev-Env",
+            "project": "example_storage",
+            "tags": [
+              "example_storage"
+            ],
+            "workspace_map": {
+              "default": "example_storage_default"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/_hcp-migrate-configs/terraform.tfstate
+++ b/_hcp-migrate-configs/terraform.tfstate
@@ -1,12 +1,79 @@
 {
   "version": 4,
   "terraform_version": "1.9.6",
-  "serial": 20,
+  "serial": 23,
   "lineage": "d4407262-3cf2-c3fa-3264-e7e9b4af44c9",
   "outputs": {
     "count_dir_skipped": {
       "value": 1,
       "type": "number"
+    },
+    "count_variables_migrated": {
+      "value": {
+        "example/compute": {
+          "count_variables_migrated": 4,
+          "workspaces_ids": [
+            "ws-21r3t1Yq59D4bdvi",
+            "ws-7WBu9JjqChvPcTsh"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_default",
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_testing"
+          ]
+        },
+        "example/storage": {
+          "count_variables_migrated": 2,
+          "workspaces_ids": [
+            "ws-MWZv4cKYHHKjs9pk"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_storage_default"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        {
+          "example/compute": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ]
+            }
+          ],
+          "example/storage": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ]
+            }
+          ]
+        }
+      ]
     },
     "list_of_new_project_ids": {
       "value": [
@@ -32,6 +99,151 @@
           "string",
           "string"
         ]
+      ]
+    },
+    "migration_pr_link": {
+      "value": [
+        "https://github.com/vjshar/tf-migration/pull/1"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string"
+        ]
+      ]
+    },
+    "workspace_ids": {
+      "value": {
+        "example/compute": {
+          "count_variables_migrated": 4,
+          "workspaces_ids": [
+            "ws-21r3t1Yq59D4bdvi",
+            "ws-7WBu9JjqChvPcTsh"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_default",
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_testing"
+          ]
+        },
+        "example/storage": {
+          "count_variables_migrated": 2,
+          "workspaces_ids": [
+            "ws-MWZv4cKYHHKjs9pk"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_storage_default"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        {
+          "example/compute": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ]
+            }
+          ],
+          "example/storage": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "workspace_urls": {
+      "value": {
+        "example/compute": {
+          "count_variables_migrated": 4,
+          "workspaces_ids": [
+            "ws-21r3t1Yq59D4bdvi",
+            "ws-7WBu9JjqChvPcTsh"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_default",
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_compute_testing"
+          ]
+        },
+        "example/storage": {
+          "count_variables_migrated": 2,
+          "workspaces_ids": [
+            "ws-MWZv4cKYHHKjs9pk"
+          ],
+          "workspaces_url": [
+            "https://app.terraform.io/app/TFC-Dev-Env/workspaces/example_storage_default"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        {
+          "example/compute": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string",
+                  "string"
+                ]
+              ]
+            }
+          ],
+          "example/storage": [
+            "object",
+            {
+              "count_variables_migrated": "number",
+              "workspaces_ids": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ],
+              "workspaces_url": [
+                "tuple",
+                [
+                  "string"
+                ]
+              ]
+            }
+          ]
+        }
       ]
     }
   },
@@ -65,6 +277,69 @@
           },
           "sensitive_attributes": [],
           "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "tfmigrate_git_commit_push",
+      "name": "create_commit",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "branch_name": "hcp-migrate-main",
+            "commit_hash": "2a2619cd337535cd6db19cb7f9e793ebdb479359",
+            "commit_message": "[skip ci] Migrating local Workspaces from learn-terraform-migrate to HCP Terraform",
+            "directory_path": "/Users/vijay/apps/terraform/tf-migrate/learn-terraform-migrate/example/compute",
+            "enable_push": true,
+            "remote_name": "origin",
+            "summary": "Git Commit with Commit Hash 2a2619cd337535cd6db19cb7f9e793ebdb479359 Completed.and Pushed"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_variable.variables",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "module.workspace_and_variables.tfmigrate_update_backend.update-backend",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "tfmigrate_github_pr",
+      "name": "migration_pr",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "destin_branch": "main",
+            "pr_body": "This PR is created by TFMigrate CLI to migrate the Workspaces from the repository vjshar/tf-migration to the app.terraform.io.",
+            "pr_title": "HCP Migration of Workspaces in vjshar/tf-migration repository",
+            "pull_request_url": "https://github.com/vjshar/tf-migration/pull/1",
+            "repo_identifier": "vjshar/tf-migration",
+            "source_branch": "hcp-migrate-main",
+            "summary": "Git PR Created: https://github.com/vjshar/tf-migration/pull/1"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_variable.variables",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "module.workspace_and_variables.tfmigrate_update_backend.update-backend",
+            "tfe_project.list_of_new_projects",
+            "tfmigrate_git_commit_push.create_commit"
+          ]
         }
       ]
     },

--- a/example/compute/main.tf
+++ b/example/compute/main.tf
@@ -6,8 +6,13 @@ terraform {
     }
   }
 
-  backend "s3" {
-    key = "learn-terraform-migrate/compute/frontend/terraform.tfstate"
+  cloud {
+    organization = "TFC-Dev-Env"
+    hostname     = "app.terraform.io"
+    workspaces {
+      project = "example_compute"
+      tags    = ["example_compute"]
+    }
   }
 }
 

--- a/example/storage/main.tf
+++ b/example/storage/main.tf
@@ -6,8 +6,13 @@ terraform {
     }
   }
 
-  backend "s3" {
-    key = "learn-terraform-migrate/example/storage/terraform.tfstate"
+  cloud {
+    organization = "TFC-Dev-Env"
+    hostname     = "app.terraform.io"
+    workspaces {
+      project = "example_storage"
+      name    = "example_storage_default"
+    }
   }
 }
 


### PR DESCRIPTION
This PR is created by TFMigrate CLI to migrate the Workspaces from the repository vjshar/tf-migration to the app.terraform.io.